### PR TITLE
Check for common supported SPDM version in GET_VERSION step

### DIFF
--- a/Include/Library/SpdmCommonLib.h
+++ b/Include/Library/SpdmCommonLib.h
@@ -34,6 +34,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 //
 
 #define MAX_SPDM_VERSION_COUNT            2
+#define MAX_SPDM_SUPPORTED_VERSION_COUNT  2
 #define MAX_SPDM_SLOT_COUNT               8
 #define MAX_SPDM_OPAQUE_DATA_SIZE         1024
 

--- a/Library/SpdmLib/SpdmCommonLib/SpdmCommonLibContextData.c
+++ b/Library/SpdmLib/SpdmCommonLib/SpdmCommonLibContextData.c
@@ -464,6 +464,10 @@ SpdmInitContext (
   SpdmContext = Context;
   ZeroMem (SpdmContext, sizeof(SPDM_DEVICE_CONTEXT));
   SpdmContext->Version = SPDM_DEVICE_CONTEXT_VERSION;
+  SpdmContext->SupportedSPDMVersions[0].MajorVersion = 1;
+  SpdmContext->SupportedSPDMVersions[0].MinorVersion = 0;
+  SpdmContext->SupportedSPDMVersions[1].MajorVersion = 1;
+  SpdmContext->SupportedSPDMVersions[1].MinorVersion = 1;
   SpdmContext->Transcript.MessageA.MaxBufferSize  = MAX_SPDM_MESSAGE_SMALL_BUFFER_SIZE;
   SpdmContext->Transcript.MessageB.MaxBufferSize  = MAX_SPDM_MESSAGE_BUFFER_SIZE;
   SpdmContext->Transcript.MessageC.MaxBufferSize  = MAX_SPDM_MESSAGE_SMALL_BUFFER_SIZE;

--- a/Library/SpdmLib/SpdmCommonLib/SpdmCommonLibInternal.h
+++ b/Library/SpdmLib/SpdmCommonLib/SpdmCommonLibInternal.h
@@ -258,6 +258,9 @@ typedef struct {
 
   // TBD: Need support multiple session
   SPDM_SESSION_INFO               SessionInfo[MAX_SPDM_SESSION_COUNT];
+
+  SPDM_VERSION_NUMBER             SupportedSPDMVersions[MAX_SPDM_SUPPORTED_VERSION_COUNT];
+  UINT8                           SPDMVersion;
 } SPDM_DEVICE_CONTEXT;
 
 typedef

--- a/Library/SpdmLib/SpdmRequesterLib/SpdmRequesterLibGetCapability.c
+++ b/Library/SpdmLib/SpdmRequesterLib/SpdmRequesterLibGetCapability.c
@@ -25,7 +25,7 @@ SpdmGetCapabilities (
   UINTN                                     SpdmResponseSize;
   
   ZeroMem (&SpdmRequest, sizeof(SpdmRequest));
-  SpdmRequest.Header.SPDMVersion = SPDM_MESSAGE_VERSION_10;
+  SpdmRequest.Header.SPDMVersion = SpdmContext->SPDMVersion;
   SpdmRequest.Header.RequestResponseCode = SPDM_GET_CAPABILITIES;
   SpdmRequest.Header.Param1 = 0;
   SpdmRequest.Header.Param2 = 0;

--- a/Library/SpdmLib/SpdmRequesterLib/SpdmRequesterLibNegotiateAlgorithm.c
+++ b/Library/SpdmLib/SpdmRequesterLib/SpdmRequesterLibNegotiateAlgorithm.c
@@ -62,7 +62,7 @@ SpdmNegotiateAlgorithms (
   SPDM_NEGOTIATE_ALGORITHMS_COMMON_STRUCT_TABLE  *StructTable;
   
   ZeroMem (&SpdmRequest, sizeof(SpdmRequest));
-  SpdmRequest.Header.SPDMVersion = SPDM_MESSAGE_VERSION_10;
+  SpdmRequest.Header.SPDMVersion = SpdmContext->SPDMVersion;
   SpdmRequest.Header.RequestResponseCode = SPDM_NEGOTIATE_ALGORITHMS;
   SpdmRequest.Header.Param1 = 3; // Number of Algorithms Structure Tables
   SpdmRequest.Header.Param2 = 0;

--- a/readme.md
+++ b/readme.md
@@ -73,8 +73,6 @@
 
 2) SPDM 1.0
 
-   GET_VERSION check
-
    FLAGS_CACHE_CAP
 
    multiple cert chains


### PR DESCRIPTION
Parse the VersionNumberEntries and find a common supported SPDM Version. Return ERROR if one is not found.

I said we "support" version 0x11 and version 0x10. Code will find the highest supported common version and use that.

CommonVersion is used in message header for GET_CAPABILITIES and NEGOTIATE_ALGORITHMS