### PR TITLE
Enable TestCryptLib RsaTest and Fix RsaGetKey bug

### DIFF
--- a/OsStub/BaseCryptLibOpenssl/Pk/CryptRsaExt.c
+++ b/OsStub/BaseCryptLibOpenssl/Pk/CryptRsaExt.c
@@ -136,21 +136,20 @@ RsaGetKey (
   }
 
   if (BnKey == NULL) {
+    *BnSize = 0;
     return FALSE;
   }
 
-  *BnSize = Size;
-  Size    = BN_num_bytes (BnKey);
-
-  if (*BnSize < Size) {
-    *BnSize = Size;
-    return FALSE;
-  }
+  *BnSize = BN_num_bytes (BnKey);
 
   if (BigNumber == NULL) {
-    *BnSize = Size;
-    return TRUE;
+    return FALSE;
   }
+
+  if (*BnSize > Size) {
+    return FALSE;
+  }
+
   *BnSize = BN_bn2bin (BnKey, BigNumber) ;
 
   return TRUE;
@@ -399,7 +398,7 @@ RsaPssSign (
   INT32         Size;
   CONST EVP_MD  *HashAlg;
   VOID          *Buffer;
-  
+
   if (RsaContext == NULL || MessageHash == NULL) {
     return FALSE;
   }

--- a/OsTest/TestCryptLib/Cryptest.c
+++ b/OsTest/TestCryptLib/Cryptest.c
@@ -57,15 +57,15 @@ CryptestMain (
     return Status;
   }
 
-  // Status = ValidateCryptRsa ();
-  // if (EFI_ERROR (Status)) {
-  //   return Status;
-  // }
+  Status = ValidateCryptRsa ();
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
 
-  // Status = ValidateCryptRsa2 ();
-  // if (EFI_ERROR (Status)) {
-  //   return Status;
-  // }
+  Status = ValidateCryptRsa2 ();
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
 
   Status = ValidateCryptX509 ();
   if (EFI_ERROR (Status)) {

--- a/OsTest/TestCryptLib/RsaVerify.c
+++ b/OsTest/TestCryptLib/RsaVerify.c
@@ -124,7 +124,7 @@ ValidateCryptRsa (
 
   KeySize = 0;
   Status = RsaGetKey (Rsa, RsaKeyN, NULL, &KeySize);
-  if (!Status || KeySize != sizeof (RsaN)) {
+  if (Status || KeySize != sizeof (RsaN)) {
     Print (L"[Fail]");
     return EFI_ABORTED;
   }
@@ -154,7 +154,7 @@ ValidateCryptRsa (
 
   KeySize = 0;
   Status = RsaGetKey (Rsa, RsaKeyE, NULL, &KeySize);
-  if (!Status || KeySize != sizeof (RsaE)) {
+  if (Status || KeySize != sizeof (RsaE)) {
     Print (L"[Fail]");
     return EFI_ABORTED;
   }
@@ -189,7 +189,7 @@ ValidateCryptRsa (
 
   KeySize = 1;
   Status = RsaGetKey (Rsa, RsaKeyN, NULL, &KeySize);
-  if (!Status || KeySize != 0) {
+  if (Status || KeySize != 0) {
     Print (L"[Fail]");
     return EFI_ABORTED;
   }
@@ -205,7 +205,7 @@ ValidateCryptRsa (
 
   KeySize = 1;
   Status = RsaGetKey (Rsa, RsaKeyE, NULL, &KeySize);
-  if (!Status || KeySize != 0) {
+  if (Status || KeySize != 0) {
     Print (L"[Fail]");
     return EFI_ABORTED;
   }
@@ -263,7 +263,7 @@ ValidateCryptRsa (
     return EFI_ABORTED;
   }
 
-  if (!RsaCheckKey (Rsa)) {
+  if (RsaCheckKey (Rsa)) {
     Print (L"[Fail]");
     return EFI_ABORTED;
   }
@@ -285,7 +285,7 @@ ValidateCryptRsa (
     return EFI_ABORTED;
   }
 
-  if (!RsaCheckKey (Rsa)) {
+  if (RsaCheckKey (Rsa)) {
     Print (L"[Fail]");
     return EFI_ABORTED;
   }


### PR DESCRIPTION
1. enable RSA test. 

2. fix RsaGetKey bug.
Make RsaGetKey function clearly.  
