### PR TITLE
Issue/16

### DIFF
--- a/Include/Hal/Library/BaseCryptLib.h
+++ b/Include/Hal/Library/BaseCryptLib.h
@@ -1822,6 +1822,218 @@ X509GetOrganizationName (
   );
 
 /**
+  Retrieve the version from one X.509 certificate.
+
+  If Cert is NULL, then return FALSE.
+  If CertSize is 0, then return FALSE.
+  If this interface is not supported, then return FALSE.
+
+  @param[in]      Cert         Pointer to the DER-encoded X509 certificate.
+  @param[in]      CertSize     Size of the X509 certificate in bytes.
+  @param[out]     Version      Pointer to the retrieved version integer.
+
+  @retval RETURN_SUCCESS           The certificate version retrieved successfully.
+  @retval RETURN_INVALID_PARAMETER If  Cert is NULL or CertSize is Zero.
+  @retval RETURN_UNSUPPORTED       The operation is not supported.
+
+**/
+RETURN_STATUS
+EFIAPI
+X509GetVersion (
+  IN      CONST UINT8   *Cert,
+  IN      UINTN         CertSize,
+  OUT     UINTN          *Version
+  );
+
+/**
+  Retrieve the serialNumber from one X.509 certificate.
+
+  If Cert is NULL, then return FALSE.
+  If CertSize is 0, then return FALSE.
+  If this interface is not supported, then return FALSE.
+
+  @param[in]      Cert         Pointer to the DER-encoded X509 certificate.
+  @param[in]      CertSize     Size of the X509 certificate in bytes.
+  @param[out]     SerialNumber  Pointer to the retrieved certificate SerialNumber bytes.
+  @param[in, out] SerialNumberSize  The size in bytes of the SerialNumber buffer on input,
+                               and the size of buffer returned SerialNumber on output.
+
+  @retval RETURN_SUCCESS           The certificate serialNumber retrieved successfully.
+  @retval RETURN_INVALID_PARAMETER If Cert is NULL or CertSize is Zero.
+                                   If SerialNumberSize is NULL.
+                                   If Certificate is invalid.
+  @retval RETURN_NOT_FOUND         If no SerialNumber exists.
+  @retval RETURN_BUFFER_TOO_SMALL  If the SerialNumber is NULL. The required buffer size
+                                   (including the final null) is returned in the
+                                   SerialNumberSize parameter.
+  @retval RETURN_UNSUPPORTED       The operation is not supported.
+**/
+RETURN_STATUS
+EFIAPI
+X509GetSerialNumber (
+  IN      CONST UINT8   *Cert,
+  IN      UINTN         CertSize,
+  OUT     UINT8         *SerialNumber,  OPTIONAL
+  IN OUT  UINTN         *SerialNumberSize
+  );
+
+/**
+  Retrieve the issuer bytes from one X.509 certificate.
+
+  If Cert is NULL, then return FALSE.
+  If CertIssuerSize is NULL, then return FALSE.
+  If this interface is not supported, then return FALSE.
+
+  @param[in]      Cert         Pointer to the DER-encoded X509 certificate.
+  @param[in]      CertSize     Size of the X509 certificate in bytes.
+  @param[out]     CertIssuer  Pointer to the retrieved certificate subject bytes.
+  @param[in, out] CertIssuerSize  The size in bytes of the CertIssuer buffer on input,
+                               and the size of buffer returned CertSubject on output.
+
+  @retval  TRUE   The certificate issuer retrieved successfully.
+  @retval  FALSE  Invalid certificate, or the CertIssuerSize is too small for the result.
+                  The CertIssuerSize will be updated with the required size.
+  @retval  FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+X509GetIssuerName (
+  IN      CONST UINT8  *Cert,
+  IN      UINTN        CertSize,
+  OUT     UINT8        *CertIssuer,
+  IN OUT  UINTN        *CertIssuerSize
+  );
+
+/**
+  Retrieve the issuer common name (CN) string from one X.509 certificate.
+
+  @param[in]      Cert             Pointer to the DER-encoded X509 certificate.
+  @param[in]      CertSize         Size of the X509 certificate in bytes.
+  @param[out]     CommonName       Buffer to contain the retrieved certificate issuer common
+                                   name string. At most CommonNameSize bytes will be
+                                   written and the string will be null terminated. May be
+                                   NULL in order to determine the size buffer needed.
+  @param[in,out]  CommonNameSize   The size in bytes of the CommonName buffer on input,
+                                   and the size of buffer returned CommonName on output.
+                                   If CommonName is NULL then the amount of space needed
+                                   in buffer (including the final null) is returned.
+
+  @retval RETURN_SUCCESS           The certificate Issuer CommonName retrieved successfully.
+  @retval RETURN_INVALID_PARAMETER If Cert is NULL.
+                                   If CommonNameSize is NULL.
+                                   If CommonName is not NULL and *CommonNameSize is 0.
+                                   If Certificate is invalid.
+  @retval RETURN_NOT_FOUND         If no CommonName entry exists.
+  @retval RETURN_BUFFER_TOO_SMALL  If the CommonName is NULL. The required buffer size
+                                   (including the final null) is returned in the
+                                   CommonNameSize parameter.
+  @retval RETURN_UNSUPPORTED       The operation is not supported.
+
+**/
+RETURN_STATUS
+EFIAPI
+X509GetIssuerCommonName (
+  IN      CONST UINT8  *Cert,
+  IN      UINTN        CertSize,
+  OUT     CHAR8        *CommonName,  OPTIONAL
+  IN OUT  UINTN        *CommonNameSize
+  );
+
+/**
+  Retrieve the issuer organization name (O) string from one X.509 certificate.
+
+  @param[in]      Cert             Pointer to the DER-encoded X509 certificate.
+  @param[in]      CertSize         Size of the X509 certificate in bytes.
+  @param[out]     NameBuffer       Buffer to contain the retrieved certificate issuer organization
+                                   name string. At most NameBufferSize bytes will be
+                                   written and the string will be null terminated. May be
+                                   NULL in order to determine the size buffer needed.
+  @param[in,out]  NameBufferSize   The size in bytes of the Name buffer on input,
+                                   and the size of buffer returned Name on output.
+                                   If NameBuffer is NULL then the amount of space needed
+                                   in buffer (including the final null) is returned.
+
+  @retval RETURN_SUCCESS           The certificate issuer Organization Name retrieved successfully.
+  @retval RETURN_INVALID_PARAMETER If Cert is NULL.
+                                   If NameBufferSize is NULL.
+                                   If NameBuffer is not NULL and *CommonNameSize is 0.
+                                   If Certificate is invalid.
+  @retval RETURN_NOT_FOUND         If no Organization Name entry exists.
+  @retval RETURN_BUFFER_TOO_SMALL  If the NameBuffer is NULL. The required buffer size
+                                   (including the final null) is returned in the
+                                   CommonNameSize parameter.
+  @retval RETURN_UNSUPPORTED       The operation is not supported.
+
+**/
+RETURN_STATUS
+EFIAPI
+X509GetIssuerOrganizationName (
+  IN      CONST UINT8   *Cert,
+  IN      UINTN         CertSize,
+  OUT     CHAR8         *NameBuffer,  OPTIONAL
+  IN OUT  UINTN         *NameBufferSize
+  );
+
+/**
+  Retrieve the Signature Algorithm (NID) from one X.509 certificate.
+
+  @param[in]      Cert             Pointer to the DER-encoded X509 certificate.
+  @param[in]      CertSize         Size of the X509 certificate in bytes.
+  @param[out]     Nid              signature algorithm
+
+  @retval  TRUE   The certificate Nid retrieved successfully.
+  @retval  FALSE  Invalid certificate, or Nid is NULL
+  @retval  FALSE  This interface is not supported.
+**/
+BOOLEAN
+EFIAPI
+X509GetSignatureType (
+  IN    CONST UINT8 *Cert,
+  IN    UINTN        CertSize,
+  OUT   INTN         *Nid
+);
+
+/**
+  Retrieve the SubjectAltName from one X.509 certificate.
+
+  @param[in]      Cert             Pointer to the DER-encoded X509 certificate.
+  @param[in]      CertSize         Size of the X509 certificate in bytes.
+  @param[out]     NameBuffer       Buffer to contain the retrieved certificate
+                                   SubjectAltName. At most NameBufferSize bytes will be
+                                   written. Maybe NULL in order to determine the size
+                                   buffer needed.
+  @param[in,out]  NameBufferSize   The size in bytes of the Name buffer on input,
+                                   and the size of buffer returned Name on output.
+                                   If NameBuffer is NULL then the amount of space needed
+                                   in buffer (including the final null) is returned.
+  @param[out]     Oid              OID of otherName
+  @param[in,out]  OidSize          the buffersize for required OID
+
+  @retval RETURN_SUCCESS           The certificate Organization Name retrieved successfully.
+  @retval RETURN_INVALID_PARAMETER If Cert is NULL.
+                                   If NameBufferSize is NULL.
+                                   If NameBuffer is not NULL and *CommonNameSize is 0.
+                                   If Certificate is invalid.
+  @retval RETURN_NOT_FOUND         If no SubjectAltName exists.
+  @retval RETURN_BUFFER_TOO_SMALL  If the NameBuffer is NULL. The required buffer size
+                                   (including the final null) is returned in the
+                                   NameBufferSize parameter.
+  @retval RETURN_UNSUPPORTED       The operation is not supported.
+
+**/
+RETURN_STATUS
+EFIAPI
+X509GetDMTFSubjectAltName (
+  IN      CONST UINT8   *Cert,
+  IN      UINTN         CertSize,
+  OUT     CHAR8         *NameBuffer,  OPTIONAL
+  IN OUT  UINTN         *NameBufferSize,
+  OUT     UINT8         *Oid,         OPTIONAL
+  IN OUT  UINTN         *OidSize
+  );
+
+/**
   Verify one X509 certificate was issued by the trusted CA.
 
   If Cert is NULL, then return FALSE.

--- a/OsStub/BaseCryptLibMbedTls/Pk/CryptX509.c
+++ b/OsStub/BaseCryptLibMbedTls/Pk/CryptX509.c
@@ -621,3 +621,243 @@ X509GetTBSCert (
 {
   return FALSE;
 }
+
+
+/**
+  Retrieve the version from one X.509 certificate.
+
+  If Cert is NULL, then return FALSE.
+  If CertSize is 0, then return FALSE.
+  If this interface is not supported, then return FALSE.
+
+  @param[in]      Cert         Pointer to the DER-encoded X509 certificate.
+  @param[in]      CertSize     Size of the X509 certificate in bytes.
+  @param[out]     Version      Pointer to the retrieved version integer.
+
+  @retval RETURN_SUCCESS           The certificate version retrieved successfully.
+  @retval RETURN_INVALID_PARAMETER If  Cert is NULL or CertSize is Zero.
+  @retval RETURN_UNSUPPORTED       The operation is not supported.
+
+**/
+RETURN_STATUS
+EFIAPI
+X509GetVersion (
+  IN      CONST UINT8   *Cert,
+  IN      UINTN         CertSize,
+  OUT     UINTN          *Version
+  )
+{
+  // TBD
+  return RETURN_SUCCESS;
+}
+
+/**
+  Retrieve the serialNumber from one X.509 certificate.
+
+  If Cert is NULL, then return FALSE.
+  If CertSize is 0, then return FALSE.
+  If this interface is not supported, then return FALSE.
+
+  @param[in]      Cert         Pointer to the DER-encoded X509 certificate.
+  @param[in]      CertSize     Size of the X509 certificate in bytes.
+  @param[out]     SerialNumber  Pointer to the retrieved certificate SerialNumber bytes.
+  @param[in, out] SerialNumberSize  The size in bytes of the SerialNumber buffer on input,
+                               and the size of buffer returned SerialNumber on output.
+
+  @retval RETURN_SUCCESS           The certificate serialNumber retrieved successfully.
+  @retval RETURN_INVALID_PARAMETER If Cert is NULL or CertSize is Zero.
+                                   If SerialNumberSize is NULL.
+                                   If Certificate is invalid.
+  @retval RETURN_NOT_FOUND         If no SerialNumber exists.
+  @retval RETURN_BUFFER_TOO_SMALL  If the SerialNumber is NULL. The required buffer size
+                                   (including the final null) is returned in the
+                                   SerialNumberSize parameter.
+  @retval RETURN_UNSUPPORTED       The operation is not supported.
+**/
+RETURN_STATUS
+EFIAPI
+X509GetSerialNumber (
+  IN      CONST UINT8   *Cert,
+  IN      UINTN         CertSize,
+  OUT     UINT8         *SerialNumber,  OPTIONAL
+  IN OUT  UINTN         *SerialNumberSize
+  )
+{
+  // TBD
+  return RETURN_SUCCESS;
+}
+
+/**
+  Retrieve the issuer bytes from one X.509 certificate.
+
+  If Cert is NULL, then return FALSE.
+  If CertIssuerSize is NULL, then return FALSE.
+  If this interface is not supported, then return FALSE.
+
+  @param[in]      Cert         Pointer to the DER-encoded X509 certificate.
+  @param[in]      CertSize     Size of the X509 certificate in bytes.
+  @param[out]     CertIssuer  Pointer to the retrieved certificate subject bytes.
+  @param[in, out] CertIssuerSize  The size in bytes of the CertIssuer buffer on input,
+                               and the size of buffer returned CertSubject on output.
+
+  @retval  TRUE   The certificate issuer retrieved successfully.
+  @retval  FALSE  Invalid certificate, or the CertIssuerSize is too small for the result.
+                  The CertIssuerSize will be updated with the required size.
+  @retval  FALSE  This interface is not supported.
+
+**/
+BOOLEAN
+EFIAPI
+X509GetIssuerName (
+  IN      CONST UINT8  *Cert,
+  IN      UINTN        CertSize,
+  OUT     UINT8        *CertIssuer,
+  IN OUT  UINTN        *CertIssuerSize
+  )
+{
+  // TBD
+  return RETURN_SUCCESS;
+}
+
+/**
+  Retrieve the issuer common name (CN) string from one X.509 certificate.
+
+  @param[in]      Cert             Pointer to the DER-encoded X509 certificate.
+  @param[in]      CertSize         Size of the X509 certificate in bytes.
+  @param[out]     CommonName       Buffer to contain the retrieved certificate issuer common
+                                   name string. At most CommonNameSize bytes will be
+                                   written and the string will be null terminated. May be
+                                   NULL in order to determine the size buffer needed.
+  @param[in,out]  CommonNameSize   The size in bytes of the CommonName buffer on input,
+                                   and the size of buffer returned CommonName on output.
+                                   If CommonName is NULL then the amount of space needed
+                                   in buffer (including the final null) is returned.
+
+  @retval RETURN_SUCCESS           The certificate Issuer CommonName retrieved successfully.
+  @retval RETURN_INVALID_PARAMETER If Cert is NULL.
+                                   If CommonNameSize is NULL.
+                                   If CommonName is not NULL and *CommonNameSize is 0.
+                                   If Certificate is invalid.
+  @retval RETURN_NOT_FOUND         If no CommonName entry exists.
+  @retval RETURN_BUFFER_TOO_SMALL  If the CommonName is NULL. The required buffer size
+                                   (including the final null) is returned in the
+                                   CommonNameSize parameter.
+  @retval RETURN_UNSUPPORTED       The operation is not supported.
+
+**/
+RETURN_STATUS
+EFIAPI
+X509GetIssuerCommonName (
+  IN      CONST UINT8  *Cert,
+  IN      UINTN        CertSize,
+  OUT     CHAR8        *CommonName,  OPTIONAL
+  IN OUT  UINTN        *CommonNameSize
+  )
+{
+  // TBD
+  return RETURN_SUCCESS;
+}
+
+/**
+  Retrieve the issuer organization name (O) string from one X.509 certificate.
+
+  @param[in]      Cert             Pointer to the DER-encoded X509 certificate.
+  @param[in]      CertSize         Size of the X509 certificate in bytes.
+  @param[out]     NameBuffer       Buffer to contain the retrieved certificate issuer organization
+                                   name string. At most NameBufferSize bytes will be
+                                   written and the string will be null terminated. May be
+                                   NULL in order to determine the size buffer needed.
+  @param[in,out]  NameBufferSize   The size in bytes of the Name buffer on input,
+                                   and the size of buffer returned Name on output.
+                                   If NameBuffer is NULL then the amount of space needed
+                                   in buffer (including the final null) is returned.
+
+  @retval RETURN_SUCCESS           The certificate issuer Organization Name retrieved successfully.
+  @retval RETURN_INVALID_PARAMETER If Cert is NULL.
+                                   If NameBufferSize is NULL.
+                                   If NameBuffer is not NULL and *CommonNameSize is 0.
+                                   If Certificate is invalid.
+  @retval RETURN_NOT_FOUND         If no Organization Name entry exists.
+  @retval RETURN_BUFFER_TOO_SMALL  If the NameBuffer is NULL. The required buffer size
+                                   (including the final null) is returned in the
+                                   CommonNameSize parameter.
+  @retval RETURN_UNSUPPORTED       The operation is not supported.
+
+**/
+RETURN_STATUS
+EFIAPI
+X509GetIssuerOrganizationName (
+  IN      CONST UINT8   *Cert,
+  IN      UINTN         CertSize,
+  OUT     CHAR8         *NameBuffer,  OPTIONAL
+  IN OUT  UINTN         *NameBufferSize
+  )
+{
+  // TBD
+  return RETURN_SUCCESS;
+}
+/**
+  Retrieve the Signature Algorithm (NID) from one X.509 certificate.
+
+  @param[in]      Cert             Pointer to the DER-encoded X509 certificate.
+  @param[in]      CertSize         Size of the X509 certificate in bytes.
+  @param[out]     Nid              signature algorithm
+
+  @retval  TRUE   The certificate Nid retrieved successfully.
+  @retval  FALSE  Invalid certificate, or Nid is NULL
+  @retval  FALSE  This interface is not supported.
+**/
+BOOLEAN
+EFIAPI
+X509GetSignatureType (
+  IN    CONST UINT8 *Cert,
+  IN    UINTN        CertSize,
+  OUT   INTN         *Nid
+)
+{
+  // TBD
+  return TRUE;
+}
+
+/**
+  Retrieve the SubjectAltName from one X.509 certificate.
+
+  @param[in]      Cert             Pointer to the DER-encoded X509 certificate.
+  @param[in]      CertSize         Size of the X509 certificate in bytes.
+  @param[out]     NameBuffer       Buffer to contain the retrieved certificate
+                                   SubjectAltName. At most NameBufferSize bytes will be
+                                   written. Maybe NULL in order to determine the size
+                                   buffer needed.
+  @param[in,out]  NameBufferSize   The size in bytes of the Name buffer on input,
+                                   and the size of buffer returned Name on output.
+                                   If NameBuffer is NULL then the amount of space needed
+                                   in buffer (including the final null) is returned.
+  @param[out]     Oid              OID of otherName
+  @param[in,out]  OidSize          the buffersize for required OID
+
+  @retval RETURN_SUCCESS           The certificate Organization Name retrieved successfully.
+  @retval RETURN_INVALID_PARAMETER If Cert is NULL.
+                                   If NameBufferSize is NULL.
+                                   If NameBuffer is not NULL and *CommonNameSize is 0.
+                                   If Certificate is invalid.
+  @retval RETURN_NOT_FOUND         If no SubjectAltName exists.
+  @retval RETURN_BUFFER_TOO_SMALL  If the NameBuffer is NULL. The required buffer size
+                                   (including the final null) is returned in the
+                                   NameBufferSize parameter.
+  @retval RETURN_UNSUPPORTED       The operation is not supported.
+
+**/
+RETURN_STATUS
+EFIAPI
+X509GetDMTFSubjectAltName (
+  IN      CONST UINT8   *Cert,
+  IN      UINTN         CertSize,
+  OUT     CHAR8         *NameBuffer,  OPTIONAL
+  IN OUT  UINTN         *NameBufferSize,
+  OUT     UINT8         *Oid,         OPTIONAL
+  IN OUT  UINTN         *OidSize
+  )
+{
+  // TBD
+  return FALSE;
+}

--- a/OsTest/TestCryptLib/X509Verify.c
+++ b/OsTest/TestCryptLib/X509Verify.c
@@ -1,4 +1,4 @@
-/** @file  
+/** @file
 
 Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -30,6 +30,19 @@ ValidateCryptX509 (
   UINTN TestBundleCertLen;
   UINT8 *TestEndCert;
   UINTN TestEndCertLen;
+  UINTN SubjectSize;
+  UINT8 *Subject;
+  UINTN CommonNameSize;
+  CHAR8 CommonName[64];
+  RETURN_STATUS Ret;
+  UINTN CertVersion;
+  UINT8  Asn1Buffer[1024];
+  UINTN  Asn1BufferLen;
+  UINTN DMTFOidSize;
+  UINT8 DMTFOid[64];
+  CONST UINT8 DMTF_OID[] = {
+    0x2B, 0x06, 0x01, 0x4, 0x01, 0x83, 0x1C, 0x82, 0x12, 0x01
+  };
 
 
   Status = ReadInputFile ("test/inter.cert.der", (VOID **)&TestCert, &TestCertLen);
@@ -122,5 +135,136 @@ ValidateCryptX509 (
   }
 
 
+  //
+  // X509 Certificate Subject Retrieving.
+  //
+  Print ("- X509 Certificate Subject Bytes Retrieving ... ");
+  SubjectSize = 0;
+  Status  = X509GetSubjectName (TestCert, TestCertLen, NULL, &SubjectSize);
+  Subject = (UINT8 *)AllocatePool (SubjectSize);
+  Status  = X509GetSubjectName (TestCert, TestCertLen, Subject, &SubjectSize);
+  FreePool(Subject);
+  if (!Status) {
+    Print ("[Fail]");
+    return EFI_ABORTED;
+  } else {
+    Print ("[Pass]");
+  }
+
+  Print ("\n- X509 Certificate Context Retrieving ... ");
+  //
+  // Get CommonName from X509 Certificate Subject
+  //
+  CommonNameSize = 64;
+  ZeroMem (CommonName, CommonNameSize);
+  Ret = X509GetCommonName (TestCert, TestCertLen, CommonName, &CommonNameSize);
+  if (RETURN_ERROR (Ret)) {
+    Print ("\n  - Retrieving Common Name - [Fail]");
+    return EFI_ABORTED;
+  } else {
+    DEBUG((DEBUG_INFO, "\n  - Retrieving Common Name = \"%s\" (Size = %d)", CommonName, CommonNameSize));
+    Print(" - [PASS]");
+  }
+
+  //
+  // Get Issuer OrganizationName from X509 Certificate Subject
+  //
+  CommonNameSize = 64;
+  ZeroMem (CommonName, CommonNameSize);
+  Ret = X509GetOrganizationName (TestCert, TestCertLen, CommonName, &CommonNameSize);
+  if (Ret != RETURN_NOT_FOUND) {
+    Print ("\n  - Retrieving Oraganization Name - [Fail]");
+    return EFI_ABORTED;
+  } else {
+    Print ("\n  - Retrieving Oraganization Name - [PASS]");
+  }
+
+  //
+  // Get Version from X509 Certificate
+  //
+  CertVersion = 0;
+  Ret = X509GetVersion(TestCert, TestCertLen, &CertVersion);
+  if (RETURN_ERROR (Ret)) {
+    Print ("\n  - Retrieving Version - [Fail]");
+    return EFI_ABORTED;
+  } else {
+    DEBUG((DEBUG_INFO, "\n  - Retrieving Version = %d - ", CertVersion));
+    Print ("[Pass]");
+  }
+
+  //
+  // Get Serial from X509 Certificate
+  //
+  Asn1BufferLen = 1024;
+  ZeroMem(Asn1Buffer, Asn1BufferLen);
+  Ret = X509GetSerialNumber(TestCert, TestCertLen, Asn1Buffer, &Asn1BufferLen);
+  if (RETURN_ERROR (Ret)) {
+    Print ("\n  - Retrieving SerialNumber - [Fail]");
+    return EFI_ABORTED;
+  } else {
+    DEBUG((DEBUG_INFO, "\n  - Retrieving SerialNumber = %d - ", *((UINT64*)Asn1Buffer)));
+    Print ("[Pass]");
+  }
+
+  //
+  // X509 Certificate Subject Retrieving.
+  //
+  Print ("\n  - Retrieving issuer Bytes ... ");
+  SubjectSize = 0;
+  Status  = X509GetIssuerName (TestCert, TestCertLen, NULL, &SubjectSize);
+  Subject = (UINT8 *)AllocatePool (SubjectSize);
+  Status  = X509GetIssuerName (TestCert, TestCertLen, Subject, &SubjectSize);
+  FreePool(Subject);
+  if (!Status) {
+    Print ("[Fail]");
+    return EFI_ABORTED;
+  } else {
+    Print (" - [Pass]");
+  }
+
+  //
+  // Get Issuer CommonName from X509 Certificate Subject
+  //
+  CommonNameSize = 64;
+  ZeroMem (CommonName, CommonNameSize);
+  Ret = X509GetIssuerCommonName (TestCert, TestCertLen, CommonName, &CommonNameSize);
+  if (RETURN_ERROR (Ret)) {
+    Print ("\n  - Retrieving Issuer Common Name - [Fail]");
+    return EFI_ABORTED;
+  } else {
+    DEBUG((DEBUG_INFO, "\n  - Retrieving Issuer Common Name = \"%s\" (Size = %d) - ", CommonName, CommonNameSize));
+    Print ("[Pass]");
+  }
+
+  //
+  // Get Issuer OrganizationName from X509 Certificate Subject
+  //
+  CommonNameSize = 64;
+  ZeroMem (CommonName, CommonNameSize);
+  Ret = X509GetIssuerOrganizationName (TestCert, TestCertLen, CommonName, &CommonNameSize);
+  if (Ret != RETURN_NOT_FOUND) {
+    Print ("\n  - Retrieving Issuer Oraganization Name - [Fail]");
+    return EFI_ABORTED;
+  } else {
+    Print ("\n  - Retrieving Issuer Oraganization Name - [Pass]");
+  }
+
+  //
+  // Get X509GetSubjectAltName
+  //
+  CommonNameSize = 64;
+  DMTFOidSize = 64;
+  ZeroMem (CommonName, CommonNameSize);
+  ZeroMem (DMTFOid, DMTFOidSize);
+  Ret = X509GetDMTFSubjectAltName(TestEndCert, TestEndCertLen, CommonName, &CommonNameSize, DMTFOid, &DMTFOidSize);
+  if (RETURN_ERROR(Ret) || CompareMem(DMTFOid, DMTF_OID, sizeof (DMTF_OID)) != 0) {
+    Print ("\n  - Retrieving  SubjectAltName otherName - [Fail]");
+    return EFI_ABORTED;
+  } else {
+    DEBUG((DEBUG_INFO, "\n  - Retrieving  SubjectAltName otherName = \"%s\" (Size = %d) ", CommonName, CommonNameSize));
+    Print ("- [Pass]");
+  }
+
+  Print ("\n");
   return EFI_SUCCESS;
 }


### PR DESCRIPTION
1. add functions to obtain X509 content. 
2. add test code
3. obtain DMTFOtherName from leaf cert generated by OpenSSL (openssl config:    subjectAltName = otherName:1.3.6.1.4.1.412.274.1;UTF8:123456)

Remain question (need to confirm):
OpenSSL generated otherName may not same as DMTFOtherName(SPDM spec DSP0274_1.1.0  section 10.8.2 Leaf certificate).

expected DMTFOtherName 1:
https://lapo.it/asn1js/#MCQGCisGAQQBgxyCEgEMFkFDTUU6V0lER0VUOjEyMzQ1Njc4OTA

expected DMTFOtherName 2:
https://lapo.it/asn1js/#MCYGCisGAQQBgxyCEgGgGAwWQUNNRTpXSURHRVQ6MTIzNDU2Nzg5MA

DMTFOtherName 3 in OpenSSL generated certificate :
https://lapo.it/asn1js/#MCigJgYKKwYBBAGDHIISAaAYDBZBQ01FOldJREdFVDoxMjM0NTY3ODkw

Question1: Which one is correct? 
Question2: How to use OpenSSL generate DMTFOtherName 1 and DMTFOtherName 2?  Maybe need code change.
